### PR TITLE
Made all.yml copy paste friendly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,8 +122,8 @@ nagios_contacts:
   - name: userA
     mail: userA@somewhere
     notify:
-    - email
-    - othermean
+      - email
+      - othermean
   - name: userB
     mail: userB@somewhere
 


### PR DESCRIPTION
There was no indent under notify which will fail playbook, if copy pasted. Therefore added indent